### PR TITLE
Added `rename` method for moving files on server.

### DIFF
--- a/ftpretty.py
+++ b/ftpretty.py
@@ -166,6 +166,10 @@ class ftpretty(object):
         """ Return the current working directory """
         return self.conn.pwd()
 
+    def rename(self, remote_from, remote_to):
+        """ Rename a file on the server """
+        return self.conn.rename(remote_from, remote_to)
+
     def close(self):
         """ End the session """
         try:


### PR DESCRIPTION
This is just a pass-through, but it would save users from accessing the `conn` attribute on the `ftpretty` object.