### PR TITLE
Add a method to upload a directory tree

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Examples
     # Get a file, save it locally
     f.get('someremote/file/on/server.txt', '/tmp/localcopy/server.txt')
 
-    or 
+    or
 
     # Get a file and write to an open file
     myfile = open('/tmp/localcopy/server.txt', 'wb')
@@ -76,6 +76,13 @@ Examples
     # Put using string data (in python 3 contents should be bytes)
     f.put(None,  'someremote/file/greeting.txt', contents='blah blah blah')
 
+    or
+
+    # Put a tree on a remote directory (similar to shutil.copytree, without following
+    # symlinks
+
+    f.upload_tree("Local/tree", "/remote/files/server")
+
     # Return a list the files in a directory
     f.list('someremote/folder')
     ['a.txt', 'b.txt']
@@ -103,11 +110,11 @@ Examples
       'size': '4096',
       'time': '02:35',
       'year': '2014'}]
-    
+
     # Change to remote directory
     f.cd('someremote/folder')
 
-    # Delete a remote file 
+    # Delete a remote file
     f.delete('someremote/folder/file.txt')
 
     # Close the connection

--- a/tests/test_ftpretty.py
+++ b/tests/test_ftpretty.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import shutil
 from datetime import datetime
 from ftpretty import ftpretty
 from compat import PY2
@@ -54,6 +55,18 @@ class FtprettyTestCase(unittest.TestCase):
             put_contents = b'test_string'
         size = self.pretty.put(None, 'AUTHORS.rst', put_contents)
         self.assertEquals(size, len(put_contents))
+
+    def test_upload_tree(self):
+
+        os.mkdir("tree")
+        f = open("tree/foo.txt", "w")
+        f.write("message")
+        os.mkdir("tree/bar")
+        f = open("tree/bar/baz.txt", "w")
+        f.write("another message")
+        tree = self.pretty.upload_tree("tree", "/tree")
+        self.assertEquals(tree, "/tree")
+        shutil.rmtree("tree")
 
     def test_get(self):
         if PY2:


### PR DESCRIPTION
@codebynumbers , working with FTP really sucks usually, but your tiny little library made it easy!

I was lacking the ability to upload tree of files (like shutil.copytree) so I added it. It would be really cool
if you can merge this and upload a new package to pypi.

As a side note, if you ever need to test against FTP servers and you prefer something more real than mocking, you can use a an FTP stub from pyftplib, very easy to integrate into your unittests, or if you want, I created a pytest plugin https://pypi.python.org/pypi/pytest-localftpserver/ for that (shameless self promotion ...)

Thank you so much!   For putting this library in github.