### PR TITLE
Raise exception if fails to put.

### DIFF
--- a/ftpretty.py
+++ b/ftpretty.py
@@ -109,8 +109,6 @@ class ftpretty(object):
         try:
             self.conn.storbinary('STOR %s' % remote_file, local_file)
             size = self.conn.size(remote_file)
-        except Exception as exc:
-            print(exc)
         finally:
             local_file.close()
             self.conn.cwd(current)


### PR DESCRIPTION
The current implementation does not raise an exception if anything goes wrong transferring a file to the FTP server.