### PR TITLE
Replace double backslash in destination path with common slash

### DIFF
--- a/ftpretty.py
+++ b/ftpretty.py
@@ -129,6 +129,7 @@ class ftpretty(object):
             ignored_names = set()
 
         try:
+            dst = dst.replace('\\', '/')
             self.conn.mkd(dst)
         except error_perm:
             pass


### PR DESCRIPTION
Uploading a tree with a multiple subfolders from a Windows machine creates folders named like `folder/subfolder1`, `folder/subfolder2` in the destination instead of creating folders with subfolders since `dst` path will be something like: `some/destination\\path`. Replacing double backslash with common slash helps.