### PR TITLE
Adds support for specifying custom connection port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,9 @@ Examples
     # kwargs are passed to underlying FTP or FTP_TLS connection
     # secure=True argument switches to an FTP_TLS connection default is False
     # passive=False disable passive connection, True is the default
-    f = ftpretty(host, user, pass, secure=True, passive=False, timeout=10)
+    # Note: port is not supported as an argument in underlying FTP or FTP_TLS but support for
+    # handling port has been internally added in ftpretty by setting FTP.port or FTP_TLS.port
+    f = ftpretty(host, user, pass, secure=True, passive=False, timeout=10, port=2121)
 
     # Get a file, save it locally
     f.get('someremote/file/on/server.txt', '/tmp/localcopy/server.txt')

--- a/ftpretty.py
+++ b/ftpretty.py
@@ -31,7 +31,7 @@ except ImportError:
 class ftpretty(object):
     """ A wrapper for FTP connections """
     conn = None
-    port = 21
+    port = None
     tmp_output = None
     relative_paths = set(['.', '..'])
 
@@ -45,11 +45,13 @@ class ftpretty(object):
         if ftp_conn:
             self.conn = ftp_conn
         elif secure and FTP_TLS:
-            FTP_TLS.port = self.port
+            if self.port:
+                FTP_TLS.port = self.port
             self.conn = FTP_TLS(host=host, user=user, passwd=password, **kwargs)
             self.conn.prot_p()
         else:
-            FTP.port = self.port
+            if self.port:
+                FTP.port = self.port
             self.conn = FTP(host=host, user=user, passwd=password, **kwargs)
 
         if not passive:

--- a/ftpretty.py
+++ b/ftpretty.py
@@ -31,18 +31,25 @@ except ImportError:
 class ftpretty(object):
     """ A wrapper for FTP connections """
     conn = None
+    port = 21
     tmp_output = None
     relative_paths = set(['.', '..'])
 
     def __init__(self, host, user, password,
             secure=False, passive=True, ftp_conn=None, **kwargs):
 
+        if 'port' in kwargs.keys():
+            self.port = kwargs['port']
+            del kwargs['port']
+
         if ftp_conn:
             self.conn = ftp_conn
         elif secure and FTP_TLS:
+            FTP_TLS.port = self.port
             self.conn = FTP_TLS(host=host, user=user, passwd=password, **kwargs)
             self.conn.prot_p()
         else:
+            FTP.port = self.port
             self.conn = FTP(host=host, user=user, passwd=password, **kwargs)
 
         if not passive:

--- a/tests/test_ftpretty.py
+++ b/tests/test_ftpretty.py
@@ -169,6 +169,9 @@ class FtprettyTestCase(unittest.TestCase):
     def test_set_pasv(self):
         ftpretty(None, None, None, ftp_conn=self.mock_ftp, passive=False)
 
+    def test_custom_port(self):
+        ftpretty(None, None, None, ftp_conn=self.mock_ftp, port=2121)
+
     def test_close(self):
         self.pretty.close()
 


### PR DESCRIPTION
I've made the changes as discussed in [this issue](https://github.com/codebynumbers/ftpretty/issues/32)

I'm new to python, if any changes are needed, please suggest.

I've modified the README and written a test case which passes the port argument.

