### PR TITLE
hotfix: Switch assertEquals to assertEqual

### DIFF
--- a/tests/test_ftpretty.py
+++ b/tests/test_ftpretty.py
@@ -15,14 +15,14 @@ class FtprettyTestCase(unittest.TestCase):
 
     def test_cd(self):
         self.pretty.cd('photos/nature/mountains')
-        self.assertEquals(self.pretty.pwd(), 'photos/nature/mountains')
+        self.assertEqual(self.pretty.pwd(), 'photos/nature/mountains')
         self.pretty._set_exists(False)
         self.assertRaises(Exception, self.pretty.cd('blah'))
 
     def test_cd_up(self):
         self.pretty.cd('photos/nature/mountains')
         self.pretty.cd('../..')
-        self.assertEquals(self.pretty.pwd(), 'photos')
+        self.assertEqual(self.pretty.pwd(), 'photos')
 
     def test_make_directory(self):
         self.pretty.cd('photos')
@@ -35,24 +35,24 @@ class FtprettyTestCase(unittest.TestCase):
         self.pretty.descend('photos/nature', True)
         self.pretty._set_exists(True)
         self.pretty.cd('mountains')
-        self.assertEquals(self.pretty.pwd(), 'photos/nature/mountains')
+        self.assertEqual(self.pretty.pwd(), 'photos/nature/mountains')
 
     def test_list(self):
         self.mock_ftp._set_files(['a.txt', 'b.txt'])
-        self.assertEquals(len(self.pretty.list()), 2)
+        self.assertEqual(len(self.pretty.list()), 2)
 
     def test_list_relative_paths(self):
         self.mock_ftp._set_files(['.', '..', 'a.txt'])
-        self.assertEquals(len(self.pretty.list(remove_relative_paths=True)), 1)
+        self.assertEqual(len(self.pretty.list(remove_relative_paths=True)), 1)
 
     def test_put_filename(self):
         size = self.pretty.put('AUTHORS.rst', 'AUTHORS.rst')
-        self.assertEquals(size, os.path.getsize('AUTHORS.rst'))
+        self.assertEqual(size, os.path.getsize('AUTHORS.rst'))
 
     def test_put_file(self):
         with open('AUTHORS.rst') as file_:
             size = self.pretty.put(file_, 'AUTHORS.rst')
-            self.assertEquals(size, os.path.getsize('AUTHORS.rst'))
+            self.assertEqual(size, os.path.getsize('AUTHORS.rst'))
 
     def test_put_contents(self):
         if PY2:
@@ -60,7 +60,7 @@ class FtprettyTestCase(unittest.TestCase):
         else:
             put_contents = b'test_string'
         size = self.pretty.put(None, 'AUTHORS.rst', put_contents)
-        self.assertEquals(size, len(put_contents))
+        self.assertEqual(size, len(put_contents))
 
     def test_upload_tree(self):
 
@@ -71,7 +71,7 @@ class FtprettyTestCase(unittest.TestCase):
         f = open("tree/bar/baz.txt", "w")
         f.write("another message")
         tree = self.pretty.upload_tree("tree", "/tree")
-        self.assertEquals(tree, "/tree")
+        self.assertEqual(tree, "/tree")
         shutil.rmtree("tree")
 
     def test_get(self):
@@ -85,7 +85,7 @@ class FtprettyTestCase(unittest.TestCase):
         self.pretty.get('remote_file.txt', 'local_copy.txt')
         self.assertTrue(os.path.isfile('local_copy.txt'))
         with open('local_copy.txt') as file:
-            self.assertEquals(file.read(), 'hello_get')
+            self.assertEqual(file.read(), 'hello_get')
         os.unlink('local_copy.txt')
 
     def test_get_filehandle(self):
@@ -98,7 +98,7 @@ class FtprettyTestCase(unittest.TestCase):
         outfile.close()
         self.assertTrue(os.path.isfile('local_copy.txt'))
         with open('local_copy.txt') as file:
-            self.assertEquals(file.read(), 'hello_file')
+            self.assertEqual(file.read(), 'hello_file')
         os.unlink('local_copy.txt')
 
     def test_get_contents(self):
@@ -108,7 +108,7 @@ class FtprettyTestCase(unittest.TestCase):
             file_contents = b'hello'
         self.mock_ftp._set_contents(file_contents)
         contents = self.pretty.get('remote_file.txt')
-        self.assertEquals(contents, file_contents)
+        self.assertEqual(contents, file_contents)
 
     def test_delete(self):
         self.assertTrue(self.pretty.delete('remote_file.txt'))
@@ -120,17 +120,17 @@ class FtprettyTestCase(unittest.TestCase):
                        "-rw-rw-r-- 1 rharrigan nobody 2085 Feb 21 13:27 multi word name.png\n" +
                        "-rw-rw-r-- 1 rharrigan wheel  195 Feb 20 2013 README.txt\n")
         files = self.pretty.list(extra=True)
-        self.assertEquals(len(files), 3)
+        self.assertEqual(len(files), 3)
 
         current_year = int(datetime.now().strftime('%Y'))
-        self.assertEquals(files[1]['name'], 'multi word name.png')
-        self.assertEquals(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
+        self.assertEqual(files[1]['name'], 'multi word name.png')
+        self.assertEqual(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
 
-        self.assertEquals(files[2]['datetime'], datetime(2013, 2, 20, 0, 0, 0))
-        self.assertEquals(files[2]['size'], 195)
-        self.assertEquals(files[2]['name'], 'README.txt')
-        self.assertEquals(files[2]['owner'], 'rharrigan')
-        self.assertEquals(files[2]['group'], 'wheel')
+        self.assertEqual(files[2]['datetime'], datetime(2013, 2, 20, 0, 0, 0))
+        self.assertEqual(files[2]['size'], 195)
+        self.assertEqual(files[2]['name'], 'README.txt')
+        self.assertEqual(files[2]['owner'], 'rharrigan')
+        self.assertEqual(files[2]['group'], 'wheel')
 
     def test_dir_parse_windows(self):
         self.mock_ftp._set_dirlist(
@@ -140,31 +140,31 @@ class FtprettyTestCase(unittest.TestCase):
         )
 
         files = self.pretty.list(extra=True)
-        self.assertEquals(len(files), 3)
+        self.assertEqual(len(files), 3)
 
-        self.assertEquals(files[2]['datetime'], datetime(2020, 1, 6, 14, 28, 0))
-        self.assertEquals(files[2]['size'], 25504938)
-        self.assertEquals(files[2]['name'], 'data.csv')
-        self.assertEquals(files[2]['owner'], None)
-        self.assertEquals(files[2]['group'], None)
+        self.assertEqual(files[2]['datetime'], datetime(2020, 1, 6, 14, 28, 0))
+        self.assertEqual(files[2]['size'], 25504938)
+        self.assertEqual(files[2]['name'], 'data.csv')
+        self.assertEqual(files[2]['owner'], None)
+        self.assertEqual(files[2]['group'], None)
 
     def test_dir_parse_patched_regex(self):
         self.mock_ftp._set_dirlist("-rw-rw-r-- 1 rharrigan read-only   47 Feb 20 11:39 Cool.txt\n" +
                        "-rw-rw-r-- 1 rharrigan nobody 2085 Feb 21 13:27 multi word name.png\n" +
                        "-rw-rw-r-- 1 rharrigan dodgy-group-name  195 Feb 20 2013 README.txt\n")
         files = self.pretty.list(extra=True)
-        self.assertEquals(len(files), 3)
+        self.assertEqual(len(files), 3)
 
         current_year = int(datetime.now().strftime('%Y'))
-        self.assertEquals(files[0]['group'], 'read-only')
-        self.assertEquals(files[1]['name'], 'multi word name.png')
-        self.assertEquals(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
+        self.assertEqual(files[0]['group'], 'read-only')
+        self.assertEqual(files[1]['name'], 'multi word name.png')
+        self.assertEqual(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
 
-        self.assertEquals(files[2]['datetime'], datetime(2013, 2, 20, 0, 0, 0))
-        self.assertEquals(files[2]['size'], 195)
-        self.assertEquals(files[2]['name'], 'README.txt')
-        self.assertEquals(files[2]['owner'], 'rharrigan')
-        self.assertEquals(files[2]['group'], 'dodgy-group-name')
+        self.assertEqual(files[2]['datetime'], datetime(2013, 2, 20, 0, 0, 0))
+        self.assertEqual(files[2]['size'], 195)
+        self.assertEqual(files[2]['name'], 'README.txt')
+        self.assertEqual(files[2]['owner'], 'rharrigan')
+        self.assertEqual(files[2]['group'], 'dodgy-group-name')
 
     def test_dir_parse_sticky_bit(self):
         self.mock_ftp._set_dirlist("-rw-rw-r-- 1 rharrigan read-only   47 Feb 20 11:39 Cool.txt\n" +
@@ -172,18 +172,18 @@ class FtprettyTestCase(unittest.TestCase):
                                    "-rw-rw-r-- 1 rharrigan dodgy-group-name  195 Feb 20 2013 README.txt\n"
                                    "drwxr-xr-t 2 rharrigan rharrigan 4096 Jan 31  2019 dist\n")
         files = self.pretty.list(extra=True)
-        self.assertEquals(len(files), 4)
+        self.assertEqual(len(files), 4)
 
         current_year = int(datetime.now().strftime('%Y'))
-        self.assertEquals(files[0]['group'], 'read-only')
-        self.assertEquals(files[1]['name'], 'multi word name.png')
-        self.assertEquals(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
+        self.assertEqual(files[0]['group'], 'read-only')
+        self.assertEqual(files[1]['name'], 'multi word name.png')
+        self.assertEqual(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
 
-        self.assertEquals(files[2]['datetime'], datetime(2013, 2, 20, 0, 0, 0))
-        self.assertEquals(files[2]['size'], 195)
-        self.assertEquals(files[2]['name'], 'README.txt')
-        self.assertEquals(files[2]['owner'], 'rharrigan')
-        self.assertEquals(files[2]['group'], 'dodgy-group-name')
+        self.assertEqual(files[2]['datetime'], datetime(2013, 2, 20, 0, 0, 0))
+        self.assertEqual(files[2]['size'], 195)
+        self.assertEqual(files[2]['name'], 'README.txt')
+        self.assertEqual(files[2]['owner'], 'rharrigan')
+        self.assertEqual(files[2]['group'], 'dodgy-group-name')
 
     def test_fallthrough(self):
         self.assertTrue(self.pretty.sendcmd('hello'), 'hello')


### PR DESCRIPTION
I just changed an obsolete assertion method : **assertEquals** to **assertEqual** :yum: 