### PR TITLE
fix: change recognition of year

### DIFF
--- a/ftpretty.py
+++ b/ftpretty.py
@@ -236,11 +236,22 @@ class ftpretty(object):
         self.tmp_output.append(line)
 
 
+def _get_year(date):
+    from dateutil.relativedelta import relativedelta
+
+    current_date = datetime.datetime.now()
+    parsed_date = parser.parse("%s" % date)
+    if current_date > parsed_date:
+        current = current_date
+    else:
+        current = current_date - relativedelta(years=1)
+    return current.strftime('%Y')
+
+   
 def split_file_info(fileinfo):
     """ Parse sane directory output usually ls -l
         Adapted from https://gist.github.com/tobiasoberrauch/2942716
     """
-    current_year = datetime.datetime.now().strftime('%Y')
     files = []
 
     unix_format = re.compile(
@@ -271,7 +282,7 @@ def split_file_info(fileinfo):
 
             date = parts[7]
             time = parts[8] if ':' in parts[8] else '00:00'
-            year = parts[8] if ':' not in parts[8] else current_year
+            year = parts[8] if ':' not in parts[8] else _get_year(date)
             dt_obj = parser.parse("%s %s %s" % (date, year, time))
 
             files.append({

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-dateutil
+libfaketime

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,8 @@ setup(
     install_requires = [
         'python-dateutil',
     ],
+    tests_require = [
+        'libfaketime'
+    ],
     test_suite = 'tests.test_ftpretty.suite',
 )

--- a/tests/test_ftpretty.py
+++ b/tests/test_ftpretty.py
@@ -1,11 +1,13 @@
 import os
 import unittest
+from libfaketime import fake_time, reexec_if_needed
 import shutil
 from datetime import datetime
 from ftpretty import ftpretty
 from compat import PY2
 from .mock_ftp import MockFTP
 
+reexec_if_needed()
 
 class FtprettyTestCase(unittest.TestCase):
 
@@ -119,10 +121,11 @@ class FtprettyTestCase(unittest.TestCase):
         self.mock_ftp._set_dirlist("-rw-rw-r-- 1 rharrigan www   47 Feb 20 11:39 Cool.txt\n" +
                        "-rw-rw-r-- 1 rharrigan nobody 2085 Feb 21 13:27 multi word name.png\n" +
                        "-rw-rw-r-- 1 rharrigan wheel  195 Feb 20 2013 README.txt\n")
-        files = self.pretty.list(extra=True)
-        self.assertEqual(len(files), 3)
+        with fake_time('2021-02-22 12:01:01'):
+            files = self.pretty.list(extra=True)
+            self.assertEqual(len(files), 3)
 
-        current_year = int(datetime.now().strftime('%Y'))
+            current_year = int(datetime.now().strftime('%Y'))
         self.assertEqual(files[1]['name'], 'multi word name.png')
         self.assertEqual(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
 
@@ -152,10 +155,11 @@ class FtprettyTestCase(unittest.TestCase):
         self.mock_ftp._set_dirlist("-rw-rw-r-- 1 rharrigan read-only   47 Feb 20 11:39 Cool.txt\n" +
                        "-rw-rw-r-- 1 rharrigan nobody 2085 Feb 21 13:27 multi word name.png\n" +
                        "-rw-rw-r-- 1 rharrigan dodgy-group-name  195 Feb 20 2013 README.txt\n")
-        files = self.pretty.list(extra=True)
-        self.assertEqual(len(files), 3)
+        with fake_time('2021-02-22 12:01:01'):
+            files = self.pretty.list(extra=True)
+            self.assertEqual(len(files), 3)
 
-        current_year = int(datetime.now().strftime('%Y'))
+            current_year = int(datetime.now().strftime('%Y'))
         self.assertEqual(files[0]['group'], 'read-only')
         self.assertEqual(files[1]['name'], 'multi word name.png')
         self.assertEqual(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))
@@ -171,10 +175,11 @@ class FtprettyTestCase(unittest.TestCase):
                                    "-rw-rw-r-- 1 rharrigan nobody 2085 Feb 21 13:27 multi word name.png\n" +
                                    "-rw-rw-r-- 1 rharrigan dodgy-group-name  195 Feb 20 2013 README.txt\n"
                                    "drwxr-xr-t 2 rharrigan rharrigan 4096 Jan 31  2019 dist\n")
-        files = self.pretty.list(extra=True)
-        self.assertEqual(len(files), 4)
-
-        current_year = int(datetime.now().strftime('%Y'))
+        with fake_time('2021-02-22 12:01:01'):
+            files = self.pretty.list(extra=True)
+            self.assertEqual(len(files), 4)
+    
+            current_year = int(datetime.now().strftime('%Y'))
         self.assertEqual(files[0]['group'], 'read-only')
         self.assertEqual(files[1]['name'], 'multi word name.png')
         self.assertEqual(files[1]['datetime'], datetime(current_year, 2, 21, 13, 27, 0))

--- a/tests/test_ftpretty.py
+++ b/tests/test_ftpretty.py
@@ -135,6 +135,23 @@ class FtprettyTestCase(unittest.TestCase):
         self.assertEqual(files[2]['owner'], 'rharrigan')
         self.assertEqual(files[2]['group'], 'wheel')
 
+    def test_dir_parse_with_past_year(self):
+        self.mock_ftp._set_dirlist("-rw-rw-r-- 1 rharrigan www   47 Feb 20 11:39 Cool.txt\n" +
+                       "-rw-rw-r-- 1 rharrigan nobody 2085 Dec 21 13:27 multi word name.png\n" +
+                       "-rw-rw-r-- 1 rharrigan wheel  195 Feb 20 2013 README.txt\n")
+        
+        with fake_time('2021-02-22 12:01:01'):
+            files = self.pretty.list(extra=True)
+        self.assertEqual(len(files), 3)
+        self.assertEqual(files[1]['name'], 'multi word name.png')
+        self.assertEqual(files[1]['datetime'], datetime(2020, 12, 21, 13, 27, 0))
+
+        self.assertEqual(files[2]['datetime'], datetime(2013, 2, 20, 0, 0, 0))
+        self.assertEqual(files[2]['size'], 195)
+        self.assertEqual(files[2]['name'], 'README.txt')
+        self.assertEqual(files[2]['owner'], 'rharrigan')
+        self.assertEqual(files[2]['group'], 'wheel')
+
     def test_dir_parse_windows(self):
         self.mock_ftp._set_dirlist(
             "01-02-20  01:39PM             25429393 ABC.csv\n"
@@ -178,7 +195,7 @@ class FtprettyTestCase(unittest.TestCase):
         with fake_time('2021-02-22 12:01:01'):
             files = self.pretty.list(extra=True)
             self.assertEqual(len(files), 4)
-    
+
             current_year = int(datetime.now().strftime('%Y'))
         self.assertEqual(files[0]['group'], 'read-only')
         self.assertEqual(files[1]['name'], 'multi word name.png')


### PR DESCRIPTION
Hi!
Recently I found some interesting things about parsing time metadata with `list(some_path, extra=True)`. 
The problem is there: https://github.com/codebynumbers/ftpretty/blob/master/ftpretty.py#L274
we need to be sure that the time we consider is not within 6 months back gap, because in this case, we will set the year to metadata as the current year (because within 6months gap we will still have a time instead of the year in response from FTP) even though if the result time will be in the future. 
For example, if we run our FTP client on the 2 Feb and files from FTP server are from Dec 2020 - we will have Dec 2021 as the year in the metadata (exactly the problem that I've met today).
So I created a naive fix for this. Will appreciate any comments and improvements.
And I'm not sure about adding new dependencies, but faking time is the only appropriate to get rid of the instability of tests way that came into my head. 